### PR TITLE
feat: 메인페이지 일정 리스트 및 상세 페이지 기능 구현

### DIFF
--- a/AI/auth.py
+++ b/AI/auth.py
@@ -41,17 +41,17 @@ async def get_current_user_optional(
     authorization: Optional[str] = Header(None),
     db: Session = Depends(get_db)
 ):
-    if authorization is None:
+    if not authorization:
         return None
     try:
         scheme, token = authorization.split()
         if scheme.lower() != "bearer":
             return None
-        payload = jwt.decode(token, config.settings.SECRET_KEY, algorithms=[config.settigns.ALGORITHM])
+        payload = jwt.decode(token, config.settings.SECRET_KEY, algorithms=[config.settings.ALGORITHM])
         username: str = payload.get("sub")
-        if username is None:
+        if not username:
             return None
-    except Exception:
+    except Exception as e:
+        print("⚠️ JWT decode 실패:", e)
         return None
-    user = db.query(models.User).filter(models.User.username == username).first()
-    return user
+    return db.query(models.User).filter(models.User.username == username).first()

--- a/AI/main.py
+++ b/AI/main.py
@@ -6,12 +6,12 @@ from contextlib import asynccontextmanager
 from routers import restaurant_router
 from routers import mealdetail_router
 from routers import desinationdetail_router
+from routers import mypage_router
 
 from routers import popular_router
 
 from routers.budget_router import router as budget_router
 from routers.quick_budget_router import router as quick_budget_router
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -31,6 +31,7 @@ app.include_router(budget_router)
 app.include_router(quick_budget_router)
 app.include_router(mealdetail_router.router)
 app.include_router(desinationdetail_router.router)
+app.include_router(mypage_router.router)
 
 app.add_middleware(
     CORSMiddleware,

--- a/AI/models.py
+++ b/AI/models.py
@@ -27,6 +27,8 @@ class Schedule(Base):
     companions = Column(String)     
     schedule_json = Column(Text)
     people_count = Column(Integer, default=1)
+    tags = Column(Text, nullable=True)
+    ai_empathy = Column(Text, nullable=True)
 
     owner = relationship("User", back_populates="schedules")
 

--- a/AI/routers/ai_router.py
+++ b/AI/routers/ai_router.py
@@ -110,11 +110,13 @@ def recommend_schedule(
             day_key = f"day{day['day']}"
             plans_to_save[day_key] = day
 
-        # 6) schedule_json에서 aiEmpathy, tags 제외하고 plans만 업데이트
+        # 6) GPT 응답에서 받은 aiEmpathy와 tags도 저장하도록 추가
         update_data = {
             "schedule_json": {
                 "plans": plans_to_save
-            }
+            },
+            "aiEmpathy": ai_response_data.get("aiEmpathy", ""),
+            "tags": ai_response_data.get("tags", [])
         }
 
         updated_schedule = crud.update_schedule(db, new_schedule.id, user_id, update_data)

--- a/AI/routers/mypage_router.py
+++ b/AI/routers/mypage_router.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import schemas, models
+from database import get_db
+from auth import get_current_user
+
+router = APIRouter(prefix="/mypage", tags=["mypage"])
+
+@router.get("/", response_model=schemas.MyPageResponse)
+def get_mypage_info(
+    current_user: models.User = Depends(get_current_user)
+):
+    return {
+        "username": current_user.username,
+        "email": current_user.email,
+    }
+
+@router.get("/schedules", response_model=list[schemas.MySimplePlan])
+def get_my_schedules(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user)
+):
+    schedules = db.query(models.Schedule).filter_by(user_id=current_user.id).all()
+    return schedules

--- a/AI/schemas.py
+++ b/AI/schemas.py
@@ -75,18 +75,13 @@ class ScheduleDBResponse(BaseModel):
     startDate: str
     endDate: str
     userEmotion: List[str]
-    with_: List[str] = Field(..., alias="companions")
-    food_types: List[str]
-    region: Optional[str] = None
-    aiEmpathy: Optional[str] = None
-    tags: Optional[List[str]] = []
-    plans: Optional[Dict[str, Any]] = {}
-    schedule_json: Optional[Dict[str, Any]]
+    companions: List[str]
+    aiEmpathy: Optional[float]
+    tags: List[str]
+    plans: Dict[str, Any]
 
     class Config:
         orm_mode = True
-        allow_population_by_field_name = True
-        allow_population_by_alias = True
 
 # 스케줄 수정 요청
 class ScheduleUpdate(BaseModel):
@@ -107,6 +102,23 @@ class RestaurantPlace(BaseModel):
     tags: List[str]
     placeId: int
     imageUrl: str  # 이미지 URL 추가
+
+class MyPageResponse(BaseModel):
+    username: str
+    email: EmailStr
+    
+    class Config:
+        orm_mode = True
+
+class MySimplePlan(BaseModel):
+    id: int
+    endCity: str = Field(..., alias="end_city")
+    startDate: str = Field(..., alias="start_date")
+    endDate: str = Field(..., alias="end_date")
+
+    class Config:
+        orm_mode = True
+        allow_population_by_alias = True
 
 # 로그인 토큰 응답
 class Token(BaseModel):

--- a/AI/services/gpt_service.py
+++ b/AI/services/gpt_service.py
@@ -259,7 +259,7 @@ def save_ai_schedule_places(plans: List[dict], db: Session):
                 VALUES (:sid, :pid, :ptype)
             """), {"sid": sched_id, "pid": pid, "ptype": ptype})
     db.commit()
-
+    
 def get_ai_schedule(db: Session, end_city: str, start_date: str, end_date: str,
                     emotions: List[str], companions: List[str], peopleCount: int) -> ScheduleAIResponse:
     places = fetch_places_from_db(db, end_city)


### PR DESCRIPTION
- 로그인한 유저의 일정 리스트 조회 API (`/schedule/my`) 구현
- 마이페이지에서 간단한 일정 정보만 반환되도록 구조화
- 상세 조회 시 (`/schedule/{id}`) GPT 응답 정보(aiEmpathy, tags, plans 포함) 반환
- 일정 생성 시 AI 일정 응답을 DB에 저장하는 로직 추가
- 관련 CRUD 및 응답 모델(`ScheduleDBResponse`) 보완
